### PR TITLE
Adds code for Amazon ElastiCache Redis

### DIFF
--- a/redis.tf
+++ b/redis.tf
@@ -1,0 +1,45 @@
+provider "aws" {
+  access_key  = "${var.aws_access_key_id}"
+  secret_key  = "${var.aws_secret_access_key}"
+  region      = "${var.aws_region}"
+}
+
+resource "aws_elasticache_subnet_group" "demo_redis_subnet_group" {
+  name       = "demo-redis-subnet-group"
+  subnet_ids = ["${var.vpc_public_sn_id}"]
+}
+
+resource "aws_elasticache_cluster" "redisInstance" {
+  cluster_id           = "demo-redis"
+  engine               = "redis"
+  node_type            = "cache.t2.micro"
+  num_cache_nodes      = 1
+  parameter_group_name = "default.redis4.0"
+  port                 = 6379
+  subnet_group_name    = "${aws_elasticache_subnet_group.demo_redis_subnet_group.name}"
+  security_group_ids   = ["${var.vpc_private_sg_id}"]
+}
+
+output "subnet_id" {
+  value = "${var.vpc_public_sn_id}"
+}
+
+output "subnet_group_name" {
+  value = "${aws_elasticache_subnet_group.demo_redis_subnet_group.name}"
+}
+
+output "engine_version" {
+  value = "${aws_elasticache_cluster.redisInstance.engine_version}"
+}
+
+output "port" {
+  value = "${aws_elasticache_cluster.redisInstance.port}"
+}
+
+output "cache_node_0_address" {
+  value = "${aws_elasticache_cluster.redisInstance.cache_nodes.0.address}"
+}
+
+output "cache_nodes_0_availability_zone" {
+  value = "${aws_elasticache_cluster.redisInstance.cache_nodes.0.availability_zone}"
+}

--- a/shippable.yml
+++ b/shippable.yml
@@ -1,0 +1,102 @@
+resources:
+# Automation scripts repo
+  - name: aws_redis_tf_repo
+    type: gitRepo
+    integration: "drship_github"
+    versionTemplate:
+      sourceName: "devops-recipes/prov_aws_redis_terraform"
+      branch: master
+
+# AWS credentials
+  - name: aws_redis_tf_creds
+    type: integration
+    integration: "drship_aws"
+
+# Terraform State
+  - name: aws_redis_tf_state
+    type: state
+
+# Output of Amazon ElastiCache Redis provisioning
+  - name: aws_redis_tf_info
+    type: params
+    versionTemplate:
+      params:
+        SEED: "initial_version"
+
+templates: &terraform-init
+  - pushd $(shipctl get_resource_state "aws_redis_tf_repo")
+  - export AWS_ACCESS_KEY_ID=$(shipctl get_integration_resource_field aws_redis_tf_creds "accessKey")
+  - export AWS_SECRET_ACCESS_KEY=$(shipctl get_integration_resource_field aws_redis_tf_creds "secretKey")
+  - shipctl copy_file_from_resource_state aws_redis_tf_state terraform.tfstate .
+  - shipctl replace terraform.tfvars
+  - terraform init
+
+jobs:
+# Provision Amazon ElastiCache Redis with Terraform
+  - name: prov_aws_redis_tf
+    type: runSh
+    steps:
+      - IN: aws_vpc_tf_info
+      - IN: aws_redis_tf_repo
+        switch: off
+      - IN: aws_redis_tf_state
+        switch: off
+      - IN: aws_redis_tf_creds
+        switch: off
+      - TASK:
+          name: prov_aws_elasticache_redis
+          runtime:
+            options:
+              env:
+                - aws_region: "us-east-1"
+          script:
+            - *terraform-init
+            - terraform apply -auto-approve -var-file=terraform.tfvars
+      - OUT: aws_redis_tf_info
+        overwrite: true
+      - OUT: aws_redis_tf_state
+    on_success:
+      script:
+        - shipctl put_resource_state_multi aws_redis_tf_info "engine_version=$(terraform output engine_version)" "port=$(terraform output port)" "cache_node_0_address=$(terraform output cache_node_0_address)" "cache_nodes_0_availability_zone=$(terraform output cache_nodes_0_availability_zone)"
+        - shipctl put_resource_state_multi aws_redis_tf_info "subnet_id=$(terraform output subnet_id)" "subnet_group_name=$(terraform output subnet_group_name)"
+    always:
+      script:
+        - shipctl copy_file_to_resource_state terraform.tfstate aws_redis_tf_state
+        - popd
+    flags:
+      - aws_elasticache
+      - redis
+      - aws
+      - terraform
+
+# De-provision Amazon ElastiCache Redis with Terraform
+  - name: deprov_aws_redis_tf
+    type: runSh
+    steps:
+      - IN: aws_redis_tf_repo
+        switch: off
+      - IN: aws_redis_tf_state
+        switch: off
+      - IN: aws_redis_tf_creds
+        switch: off
+      - IN: aws_redis_tf_info
+        switch: off
+      - TASK:
+          name: deprov_aws_elasticache_redis
+          runtime:
+            options:
+              env:
+                - aws_region: "us-east-1"
+          script:
+            - *terraform-init
+            - terraform destroy -force -auto-approve -var-file=terraform.tfvars
+      - OUT: aws_redis_tf_state
+    always:
+      script:
+        - shipctl copy_file_to_resource_state terraform.tfstate aws_redis_tf_state
+        - popd
+    flags:
+      - aws_elasticache
+      - redis
+      - aws
+      - terraform

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,0 +1,5 @@
+aws_access_key_id="${AWS_ACCESS_KEY_ID}"
+aws_secret_access_key="${AWS_SECRET_ACCESS_KEY}"
+aws_region="${aws_region}"
+vpc_public_sn_id="${vpc_public_sn_id}"
+vpc_private_sg_id="${vpc_private_sg_id}"

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,19 @@
+variable "aws_access_key_id" {
+  description = "AWS access key"
+}
+
+variable "aws_secret_access_key" {
+  description = "AWS secret access key"
+}
+
+variable "aws_region" {
+  description = "AWS region"
+}
+
+variable "vpc_public_sn_id" {
+  description = "Subnet ID for spinning up Redis instances"
+}
+
+variable "vpc_private_sg_id" {
+  description = "Security group ID for Redis instances"
+}


### PR DESCRIPTION
https://github.com/devops-recipes/prov_aws_redis_terraform/issues/1

Code is similar to the setup of memcached, which was done previously. This PR was verified by running the jobs in my sample pipeline.

![image](https://user-images.githubusercontent.com/4211715/42496254-1231ab28-8443-11e8-9262-f6f99dc74dbc.png)

- [Provision Redis Job](https://app.shippable.com/github/sample-organisation/jobs/prov_aws_redis_tf/builds/5b4459f5a3a4cd07008b7966/)
- [Destroy Redis Job](https://app.shippable.com/github/sample-organisation/jobs/deprov_aws_redis_tf/builds/5b445b8f749c2107001dff83/console)

